### PR TITLE
Add tracking of installed development source for updates.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,29 @@
 
 # Stretch Version by davecrump on 201903030
 
+GIT_SRC="BritishAmateurTelevisionClub"
+GIT_SRC_FILE=".portsdown_gitsrc"
+
+if [ "$1" == "-d" ]; then
+  GIT_SRC="davecrump";
+  echo "WARNING: Installing development version, press enter to continue or 'q' to quit.";
+  read -n1 -r -s key;
+  if [[ $key == q ]]; then
+    exit 1;
+  fi
+  echo "ok!";
+elif [ "$1" == "-u" -a ! -z "$2" ]; then
+  GIT_SRC="$2"
+  echo "WARNING: Installing ${GIT_SRC} development version, press enter to continue or 'q' to quit."
+  read -n1 -r -s key;
+  if [[ $key == q ]]; then
+    exit 1;
+  fi
+  echo "ok!";
+else
+  echo "Installing BATC Production portsdown.";
+fi
+
 # Update the package manager
 sudo dpkg --configure -a
 sudo apt-get update
@@ -61,16 +84,7 @@ sudo /home/pi/LimeSuite/udev-rules/install.sh
 echo "42f752a" >/home/pi/LimeSuite/commit_tag.txt
 cd /home/pi
 
-# Check which rpidatv source to download.  Default is production
-# option d is development from davecrump
-if [ "$1" == "-d" ]; then
-  echo "Installing development load"
-  wget https://github.com/davecrump/portsdown/archive/master.zip
-
-else
-  echo "Installing BATC Production load"
-  wget https://github.com/BritishAmateurTelevisionClub/portsdown/archive/master.zip
-fi
+wget https://github.com/${GIT_SRC}/portsdown/archive/master.zip
 
 # Unzip the rpidatv software and copy to the Pi
 unzip -o master.zip
@@ -78,15 +92,7 @@ mv portsdown-master rpidatv
 rm master.zip
 cd /home/pi
 
-# Check which avc2ts to download.  Default is production
-# option d is development from davecrump
-if [ "$1" == "-d" ]; then
-  echo "Installing development avc2ts"
-  wget https://github.com/davecrump/avc2ts/archive/master.zip
-else
-  echo "Installing BATC Production avc2ts"
-  wget https://github.com/BritishAmateurTelevisionClub/avc2ts/archive/master.zip
-fi
+wget https://github.com/${GIT_SRC}/avc2ts/archive/master.zip
 
 # Unzip the avc2ts software and copy to the Pi
 unzip -o master.zip
@@ -390,6 +396,9 @@ then
 else
   echo "Completed English Install"
 fi
+
+# Save git source used
+echo "${GIT_SRC}" > /home/pi/${GIT_SRC_FILE}
 
 # Reboot
 printf "\nA reboot is required before using the software\n\n"

--- a/scripts/check_for_update.sh
+++ b/scripts/check_for_update.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
+GIT_SRC_FILE=".portsdown_gitsrc"
+if [ -e ${GIT_SRC_FILE} ]; then
+  GIT_SRC=$(</home/pi/${GIT_SRC_FILE})
+else
+  GIT_SRC="BritishAmateurTelevisionClub"
+fi
+
 ## Download the latest_version file
 cd /home/pi/rpidatv/scripts
 rm /home/pi/rpidatv/scripts/latest_version.txt  >/dev/null 2>/dev/null
-wget --timeout=2 https://raw.githubusercontent.com/BritishAmateurTelevisionClub/portsdown/master/scripts/latest_version.txt
+wget --timeout=2 https://raw.githubusercontent.com/${GIT_SRC}/portsdown/master/scripts/latest_version.txt
 
 ## Create the file if it doesn't exist
 if  [ ! -f "latest_version.txt" ]; then

--- a/update.sh
+++ b/update.sh
@@ -2,6 +2,29 @@
 
 # Updated by davecrump 201904200
 
+GIT_SRC_FILE=".portsdown_gitsrc"
+if [ -e ${GIT_SRC_FILE} ]; then
+  GIT_SRC=$(</home/pi/${GIT_SRC_FILE})
+else
+  GIT_SRC="BritishAmateurTelevisionClub"
+fi
+
+reset
+
+if [ "$1" == "-d" ]; then
+  echo "Overriding to update to latest development version"
+  GIT_SRC="davecrump"
+fi
+
+if [ "$GIT_SRC" == "BritishAmateurTelevisionClub" ]; then
+  echo "Updating to latest Production Portsdown build";
+elif [ "$GIT_SRC" == "davecrump" ]; then
+  echo "Updating to latest development Portsdown build";
+else
+  echo "Updating to latest ${GIT_SRC} development Portsdown build";
+fi
+
+
 DisplayUpdateMsg() {
   # Delete any old update message image  201802040
   rm /home/pi/tmp/update.jpg >/dev/null 2>/dev/null
@@ -33,8 +56,6 @@ DisplayRebootMsg() {
   sudo fbi -T 1 -noverbose -a /home/pi/tmp/update.jpg >/dev/null 2>/dev/null
   (sleep 1; sudo killall -9 fbi >/dev/null 2>/dev/null) &  ## kill fbi once it has done its work
 }
-
-reset
 
 printf "\nCommencing update.\n\n"
 
@@ -159,17 +180,7 @@ DisplayUpdateMsg "Step 5 of 10\nDownloading Portsdown SW\n\nXXXXX-----"
 
 cd /home/pi
 
-# Check which source to download.  Default is production
-# option -p or null is the production load
-# option -d is development from davecrump
-
-if [ "$1" == "-d" ]; then
-  echo "Installing development load"
-  wget https://github.com/davecrump/portsdown/archive/master.zip -O master.zip
-else
-  echo "Installing BATC Production load"
-  wget https://github.com/BritishAmateurTelevisionClub/portsdown/archive/master.zip -O master.zip
-fi
+wget https://github.com/${GIT_SRC}/portsdown/archive/master.zip -O master.zip
 
 # Unzip and overwrite where we need to
 unzip -o master.zip
@@ -192,15 +203,7 @@ else
   echo "avc2ts dependencies required and will be installed after avc2ts"
 fi
 
-# Check which avc2ts to download.  Default is production
-# option d is development from davecrump
-if [ "$1" == "-d" ]; then
-  echo "Installing development avc2ts"
-  wget https://github.com/davecrump/avc2ts/archive/master.zip
-else
-  echo "Installing BATC Production avc2ts"
-  wget https://github.com/BritishAmateurTelevisionClub/avc2ts/archive/master.zip
-fi
+wget https://github.com/${GIT_SRC}/avc2ts/archive/master.zip
 
 # Unzip the avc2ts software
 unzip -o master.zip


### PR DESCRIPTION
For consideration and comment, allows others (ie. me) to be able to use your development workflow within their own repositories.

Adds './install.sh -u <github user>' option to install using that user's github repos. All future update checks and updates will then run against that user (reference stored in '.portsdown_gitsrc')

Changes the update flow slightly - the check_for_updates will now only check the user repository that it was installed with. Changing 'channel' requires a manual edit to the '.portsdown_gitsrc' file that contains the github username. This will mean that your development builds will be default check your 'davecrump' repositories for updates.

Non-development users will have no difference in behaviour.